### PR TITLE
Hotfix for v3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,11 @@ actual calculation output would be stored.
 If you use ADG in your research work, we kindly ask you to cite the following
 papers:
   - P. Arthuis, T. Duguet, A. Tichai, R.-D. Lasseri and J.-P. Ebran,
-    Comput. Phys. Commun. **240**, 202-227 (2019). It is available under the
-    following [DOI](https://doi.org/10.1016/j.cpc.2018.11.023).
+    [Comput. Phys. Commun. **240**, 202-227](https://doi.org/10.1016/j.cpc.2018.11.023) (2019).
   - P. Arthuis, A. Tichai, J. Ripoche and T. Duguet,
-    Comput. Phys. Commun. **261**, 107677 (2021). It is available [here](https://doi.org/10.1016/j.cpc.2020.107677).
+    [Comput. Phys. Commun. **261**, 107677](https://doi.org/10.1016/j.cpc.2020.107677) (2021).
+  - A. Tichai, P. Arthuis, H. Hergert and T. Duguet,
+    [arXiv:2102.10889](https://arxiv.org/abs/2102.10889) (2021).
 
 ## License
 ADG is licensed under GNU General Public License version 3 (see LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ papers:
 ADG is licensed under GNU General Public License version 3 (see LICENSE.txt).
 ```
 Copyright (C) 2018-2021 ADG Dev Team
-Pierre Arthuis - IKP, TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previously University of Surrey & Irfu, CEA, Université Paris-Saclay & CEA, DAM, DIF)
+Pierre Arthuis - TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previously University of Surrey & Irfu, CEA, Université Paris-Saclay & CEA, DAM, DIF)
 Thomas Duguet - Irfu, CEA, UPSaclay & KU Leuven, IKS
 Jean-Paul Ebran - CEA, DAM, DIF
 Heiko Hergert - NSCL/FRIB Laboratory & Department of Physics and Astronomy, Michigan State University
 Raphaël-David Lasseri - ESNT, Irfu, CEA, UPSaclay (previously IPN, CNRS/IN2P3, UPSud, UPSaclay)
 Julien Ripoche - CEA, DAM, DIF
-Alexander Tichai - MPI fuer Kernphysik, Heidelberg & IKP, TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previsously ESNT, Irfu, CEA, Université Paris-Saclay)
+Alexander Tichai - MPI fuer Kernphysik, Heidelberg & TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previsously ESNT, Irfu, CEA, Université Paris-Saclay)
 ```

--- a/adg/__init__.py
+++ b/adg/__init__.py
@@ -1,6 +1,6 @@
 """Information on the ADG module."""
 
 __license__ = 'GPLv3'
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 __author__ = 'ADG Dev Team'
 __email__ = 'pierre.arthuis@protonmail.com'

--- a/adg/bimsrg.py
+++ b/adg/bimsrg.py
@@ -206,6 +206,7 @@ def permutator(set_1, set_2):
     """
     perm_op = 'P(%s/%s) &= 1 ' % ("".join('k_{%i}' % label for label in set_1),
                                   "".join('k_{%i}' % label for label in set_2))
+    perm_counter = 0
     # Combine all possible subsets of both sets
     for subset_1, subset_2 in product(powerset(set_1), powerset(set_2)):
         # Ensure each qp state has a permutation partner, exclude the empty set
@@ -215,7 +216,15 @@ def permutator(set_1, set_2):
                 perm_op += '+ ' if len(subset_1) % 2 == 0 else '- '
                 for elem in zip(permutation, subset_2):
                     perm_op += 'P_{k_{%i} k_{%i}} ' % elem
-    perm_op += "\\\\\n"
+                    perm_counter += 1
+                # Avoid permutators lines being too long
+                if perm_counter >= 10:
+                    perm_op += '\\\\\n &\\phantom{=} '
+                    perm_counter = 0
+    if perm_op.endswith('\\\\\n &\\phantom{=} '):
+        perm_op = perm_op[:-len(' &\\phantom{=} ')]
+    else:
+        perm_op += "\\\\\n"
     return perm_op
 
 

--- a/adg/bimsrg.py
+++ b/adg/bimsrg.py
@@ -274,8 +274,11 @@ class BimsrgDiagram(adg.diag.Diagram):
         B_degrees = self.unsort_io_degrees[1] \
             if self.graph.nodes[1]['operator'] == 'B' \
             else self.unsort_io_degrees[2]
-        name = " C^{%i%i}(%i%i,%i%i) = " \
+        name = " C^{%i%i}_{%s}(%i%i,%i%i) = " \
             % (self.unsort_degrees[3], self.unsort_degrees[0],
+               "".join('k_{%i}' % (idx + 1) for idx
+                       in range(self.unsort_degrees[3]
+                                + self.unsort_degrees[0])),
                A_degrees[1], A_degrees[0], B_degrees[1], B_degrees[0])
         return name + self.sign() + self.permutator() \
             + self.symmetry_factor() + self.vertices_expression()

--- a/adg/run.py
+++ b/adg/run.py
@@ -474,6 +474,7 @@ def write_file_header(latex_file, commands, diags_nbs):
             + "\\author{The ADG Dev Team}\n"
     else:
         header = header \
+            + "\\allowdisplaybreaks\n\n" \
             + "\\title{Diagrams and algebraic expressions at order (%i,%i;%i) in BIMSRG}\n" \
             % commands.order \
             + "\\author{The ADG Dev Team}\n"

--- a/adg/run.py
+++ b/adg/run.py
@@ -121,6 +121,10 @@ def parse_command_line(cli_args):
         else:
             print("Truncation order has to be three int at most. Exiting.")
             exit()
+        if args.draw_diags and max(args.order) >= 7:
+            args.draw_diags = False
+            print("Diagram drawing is not supported for BIMSRG above order 6.")
+            print("The '-d' flag has been deactivated.")
     else:
         dummy_order = args.order[0]
         args.order = dummy_order
@@ -181,6 +185,12 @@ def interactive_interface(commands):
     commands.draw_diags = input(
         "Generate diagrams FeynMF instructions in TeX file? (y/N) "
         ).lower() == 'y'
+
+    if commands.theory == "BIMSRG" and commands.draw_diags \
+            and max(commands.order) >= 7:
+        commands.draw_diags = False
+        print("Diagram drawing is not supported for BIMSRG above order 6.")
+        print("The '-d' flag has been deactivated.")
 
     if commands.theory == "MBPT":
         commands.cd_output = input(

--- a/adg/tests/test_bimsrg.py
+++ b/adg/tests/test_bimsrg.py
@@ -18,7 +18,7 @@ def test_attribute_expressions():
     adg.diag.label_vertices([graph], "BIMSRG", 2)
     diag = adg.bimsrg.BimsrgDiagram(graph, 0)
 
-    diag_ref = ' C^{20}(11,20) = P(k_{1}/k_{2}) ' \
+    diag_ref = ' C^{20}_{k_{1}k_{2}}(11,20) = P(k_{1}/k_{2}) ' \
         + '\\sum_{p_{1}} A^{11}_{k_{1} p_{1}} B^{20}_{p_{1} k_{2}}'
 
     assert diag.expr == diag_ref
@@ -88,7 +88,7 @@ def test_write_section():
         + '\\subsection{$C^{20}$}\n\n' \
         + '\\paragraph{Diagram 1 ($+AB$):}\n' \
         + '\\begin{equation}\n' \
-        + ' C^{20}(11,20) = P(k_{1}/k_{2}) ' \
+        + ' C^{20}_{k_{1}k_{2}}(11,20) = P(k_{1}/k_{2}) ' \
         + '\\sum_{p_{1}} A^{11}_{k_{1} p_{1}} B^{20}_{p_{1} k_{2}}\n' \
         + '\\end{equation}\n'
 

--- a/doc/build/man/adg.1
+++ b/doc/build/man/adg.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "ADG" "1" "Feb 15, 2021" "3.0.0" "ADG - Automated Diagram Generator"
+.TH "ADG" "1" "Jun 16, 2021" "3.0.1" "ADG - Automated Diagram Generator"
 .SH NAME
 adg \- ADG - Automated Diagram Generator Documentation
 .
@@ -3370,7 +3370,7 @@ They have been involved in the making of ADG over the past years:
 .INDENT 3.5
 .INDENT 0.0
 .IP \(bu 2
-Pierre Arthuis \- IKP, TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previously University of Surrey & Irfu, CEA, Université Paris\-Saclay & CEA, DAM, DIF)
+Pierre Arthuis \- TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previously University of Surrey & Irfu, CEA, Université Paris\-Saclay & CEA, DAM, DIF)
 .IP \(bu 2
 Thomas Duguet \- Irfu, CEA, Université Paris\-Saclay & KU Leuven, IKS
 .IP \(bu 2
@@ -3382,7 +3382,7 @@ Raphaël\-David Lasseri \- ESNT, Irfu, CEA, Université Paris\-Saclay (previousl
 .IP \(bu 2
 Julien Ripoche \- CEA, DAM, DIF
 .IP \(bu 2
-Alexander Tichai \- MPI fuer Kernphysik, Heidelberg & IKP, TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previsously ESNT, Irfu, CEA, Université Paris\-Saclay)
+Alexander Tichai \- MPI fuer Kernphysik, Heidelberg & TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previsously ESNT, Irfu, CEA, Université Paris\-Saclay)
 .UNINDENT
 .UNINDENT
 .UNINDENT
@@ -3400,6 +3400,9 @@ following \fI\%DOI\fP\&.
 .IP \(bu 2
 P. Arthuis, A. Tichai, J. Ripoche and T. Duguet,
 Comput. Phys. Commun. \fB261\fP, 107677 (2021). It is available \fI\%here\fP\&.
+.IP \(bu 2
+A. Tichai, P. Arthuis, H. Hergert and T. Duguet,
+\fI\%arXiv:2102.10889\fP (2021).
 .UNINDENT
 .UNINDENT
 .UNINDENT

--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -8,6 +8,9 @@ papers:
     following DOI_.
   - P. Arthuis, A. Tichai, J. Ripoche and T. Duguet,
     Comput. Phys. Commun. **261**, 107677 (2021). It is available here_.
+  - A. Tichai, P. Arthuis, H. Hergert and T. Duguet,
+    arXiv:2102.10889_ (2021).
 
 .. _DOI: https://doi.org/10.1016/j.cpc.2018.11.023
 .. _here: https://doi.org/10.1016/j.cpc.2020.107677
+.. _arXiv:2102.10889: https://arxiv.org/abs/2102.10889

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -3,10 +3,10 @@ Developers Team
 
 They have been involved in the making of ADG over the past years:
 
-  - Pierre Arthuis - IKP, TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previously University of Surrey & Irfu, CEA, Université Paris-Saclay & CEA, DAM, DIF)
+  - Pierre Arthuis - TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previously University of Surrey & Irfu, CEA, Université Paris-Saclay & CEA, DAM, DIF)
   - Thomas Duguet - Irfu, CEA, Université Paris-Saclay & KU Leuven, IKS
   - Jean-Paul Ebran - CEA, DAM, DIF
   - Heiko Hergert - NSCL/FRIB Laboratory & Department of Physics and Astronomy, Michigan State University
   - Raphaël-David Lasseri - ESNT, Irfu, CEA, Université Paris-Saclay (previously IPN, CNRS/IN2P3, Université Paris-Sud, Université Paris-Saclay)
   - Julien Ripoche - CEA, DAM, DIF
-  - Alexander Tichai - MPI fuer Kernphysik, Heidelberg & IKP, TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previsously ESNT, Irfu, CEA, Université Paris-Saclay)
+  - Alexander Tichai - MPI fuer Kernphysik, Heidelberg & TU Darmstadt & ExtreMe Matter Institute EMMI, GSI, Darmstadt (previsously ESNT, Irfu, CEA, Université Paris-Saclay)


### PR DESCRIPTION
- Fix qp labels in BIMSRG diagrams expressions
- Add BIMSRG pre-print to README and doc
- Make sure permutation operators are properly displayed
- Avoid program crashes for BIMSRG with 7-body operators and higher
- Fix broken tests
- Use updated affiliation for TUDa 